### PR TITLE
Add upload_media method

### DIFF
--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -231,9 +231,9 @@ module Twitter
         update!(status, options.merge(media_ids: media_ids.join(',')))
       end
 
-      def update_with_media_key(status, media_key, options = {})
+      def update_with_media_ids(status, media_ids, options = {})
         options = options.dup
-        update!(status, options.merge(media_ids: [media_key]))
+        update!(status, options.merge(media_ids: [media_ids]))
       end
 
       def upload_media(media)

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -237,7 +237,7 @@ module Twitter
       end
 
       def upload_media(media)
-        upload(media)[:media_id]
+        upload(media)[:media_key]
       end
 
       # Returns oEmbed for a Tweet

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -233,7 +233,7 @@ module Twitter
 
       def update_with_media_ids(status, media_ids, options = {})
         options = options.dup
-        update!(status, options.merge(media_ids: [media_ids]))
+        update!(status, options.merge(media_ids: media_ids.join(',')))
       end
 
       def upload_media(media)

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -231,6 +231,15 @@ module Twitter
         update!(status, options.merge(media_ids: media_ids.join(',')))
       end
 
+      def update_with_media_key(status, media_key, options = {})
+        options = options.dup
+        update!(status, options.merge(media_ids: [media_key]))
+      end
+
+      def upload_media(media)
+        upload(media)[:media_id]
+      end
+
       # Returns oEmbed for a Tweet
       #
       # @see https://dev.twitter.com/rest/reference/get/statuses/oembed

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -231,11 +231,6 @@ module Twitter
         update!(status, options.merge(media_ids: media_ids.join(',')))
       end
 
-      def update_with_media_ids(status, media_ids, options = {})
-        options = options.dup
-        update!(status, options.merge(media_ids: media_ids.join(',')))
-      end
-
       def upload_media(media)
         upload(media)
       end

--- a/lib/twitter/rest/tweets.rb
+++ b/lib/twitter/rest/tweets.rb
@@ -237,7 +237,7 @@ module Twitter
       end
 
       def upload_media(media)
-        upload(media)[:media_key]
+        upload(media)
       end
 
       # Returns oEmbed for a Tweet


### PR DESCRIPTION
### Card e Pull Request em elife/buzz_monitor_app
https://github.com/elifebr/buzz_monitor_app/pull/2441

### O que foi feito

Adiciona o método público `upload_media` que encapsula o método privado `upload`. Este método faz com que seja possível pegar o `media_id` da resposta a requisição ao fazer um upload de uma mídia, o que é necessário para gerar o media_key dela e conseguir adicioná-la à Biblioteca de Mídia do Twitter Ads 